### PR TITLE
updated Module forkUrl usage, if set, use exact the given URL as forkUrl

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -73,7 +73,7 @@ class DefaultController extends Controller
                 'toc' => $toc,
                 'headline' => $headline,
                 'breadcrumbs' => explode('/', $file),
-                'forkUrl' => $this->module->forkUrl.'/'.$file
+                'forkUrl' => (!empty($this->module->forkUrl)) ? $this->module->forkUrl : false,
             ]
         );
     }


### PR DESCRIPTION
So it can be completely disabled if not wanted. The previous state generates an unusable relative URL if the `forkUrl` property is not set